### PR TITLE
Remove pointer to Pawns bitboard

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -15,9 +15,9 @@ int main(int, char**) {
     std::shared_ptr<Bitboard> empty_squares_ptr = std::make_shared<Bitboard> (~occupied_squares);
 
     auto WhitePieces = std::make_shared<pieces::White>(white_pieces, black_pieces);
-    auto WhitePawns = pieces::Pawns(white_pawns, empty_squares_ptr, WhitePieces);
+    auto WhitePawns = pieces::Pawns(empty_squares_ptr, WhitePieces);
+    WhitePawns.standard_starting_position();
 
-    Bitboard pawn_targets = 0;
     auto pawn_moves = WhitePawns.single_pushes();
 
     print_board(pawn_moves.get_target());

--- a/pieces.cpp
+++ b/pieces.cpp
@@ -18,18 +18,18 @@ std::shared_ptr<Piece> ChessMen::get_piece(Square square_index) {
 ///////////////////////////////////////////////////////////////////////////////
 
 Bitboard Pawns::all_attacked_squares() {
-    return colour->pawn_west_attack_targets(*board) | colour->pawn_east_attack_targets(*board);
+    return colour->pawn_west_attack_targets(board) | colour->pawn_east_attack_targets(board);
 };
 
 Bitboard Pawns::single_push() {
-    return colour->pawn_push_sources(*empty_squares) & *board;;
+    return colour->pawn_push_sources(*empty_squares) & board;;
 }
 
 Bitboard Pawns::double_push() {
     Bitboard empty_targets, clear_to_target;
     empty_targets = colour->pawn_double_push_target() & *empty_squares;
     clear_to_target = colour->pawn_push_sources(empty_targets) & *empty_squares;
-    return colour->pawn_push_sources(clear_to_target) & *board;
+    return colour->pawn_push_sources(clear_to_target) & board;
 }
 
 PawnTargets Pawns::single_pushes() {
@@ -47,23 +47,31 @@ PawnTargets Pawns::double_pushes() {
 }
         
 PawnTargets Pawns::west_captures() {
-    auto sources = colour->pawn_west_attack_sources() & *board;
+    auto sources = colour->pawn_west_attack_sources() & board;
     auto targets = colour->pawn_west_attack_targets(sources);
     return PawnTargets(sources, targets);
 }
         
 PawnTargets Pawns::east_captures() {
-    auto sources = colour->pawn_east_attack_sources() & *board;
+    auto sources = colour->pawn_east_attack_sources() & board;
     auto targets = colour->pawn_east_attack_targets(sources);
     return PawnTargets(sources, targets);
 }
+
+void Pawns::standard_starting_position() {
+    board = colour->pawn_standard_starting_position();
+}
+
+Bitboard Pawns::current_position() { 
+    return board; 
+};
 
 void Pawns::make_move(Square source, Square target) {
     auto source_bitboard = Bitboard(1) << source;
     auto target_bitboard = Bitboard(1) << target;
     auto source_and_target_bitboard = source_bitboard ^ target_bitboard;
 
-    *board ^= source_and_target_bitboard;
+    board ^= source_and_target_bitboard;
     *empty_squares ^= source_and_target_bitboard;
     colour->make_move(source_and_target_bitboard);
 }
@@ -71,7 +79,7 @@ void Pawns::make_move(Square source, Square target) {
 void Pawns::make_capture(Square target) {
     auto target_bitboard = Bitboard(1) << target;
 
-    *board ^= target_bitboard;
+    board ^= target_bitboard;
     *empty_squares ^= target_bitboard;
     colour->make_move(target_bitboard);
 }
@@ -79,7 +87,7 @@ void Pawns::make_capture(Square target) {
 bool Pawns::has_piece_on_square(Square square_index) {
     auto target_bitboard = Bitboard(1) << square_index;
     
-    return (target_bitboard & *board) > 0;
+    return (target_bitboard & board) > 0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -166,6 +174,10 @@ bool Pawns::has_piece_on_square(Square square_index) {
 //     piece_to_move.make_move(source, target);
 // }
 
+Bitboard White::pawn_standard_starting_position() {
+    return bitboard::RANK_2;
+}
+
 Bitboard White::pawn_push_targets(Bitboard sources) {
     return bitboard::north_one(sources);
 }
@@ -198,6 +210,10 @@ void White::make_move(Bitboard source_and_target_bitboard) {
     *this_colour_pieces ^= source_and_target_bitboard;
 }
 
+
+Bitboard Black::pawn_standard_starting_position() {
+    return bitboard::RANK_7;
+}
 
 Bitboard Black::pawn_push_targets(Bitboard sources) {
     return bitboard::south_one(sources);

--- a/pieces.h
+++ b/pieces.h
@@ -26,6 +26,7 @@ class PawnTargets {
 
 class Colour {
     public:
+        virtual Bitboard pawn_standard_starting_position() = 0;
         virtual Bitboard pawn_push_targets(Bitboard sources) = 0;
         virtual Bitboard pawn_push_sources(Bitboard targets) = 0;
         virtual Bitboard pawn_east_attack_targets(Bitboard sources) = 0;
@@ -44,6 +45,7 @@ class Black : public Colour {
         Black(std::shared_ptr<Bitboard> this_colour_pieces, 
             std::shared_ptr<Bitboard> opponent_pieces)
             : this_colour_pieces(this_colour_pieces), opponent_pieces(opponent_pieces) {};
+        Bitboard pawn_standard_starting_position() override;
         Bitboard pawn_push_targets(Bitboard sources) override;
         Bitboard pawn_push_sources(Bitboard targets) override;
         Bitboard pawn_east_attack_targets(Bitboard sources) override;
@@ -62,6 +64,7 @@ class White : public Colour {
         White(std::shared_ptr<Bitboard> this_colour_pieces, 
             std::shared_ptr<Bitboard> opponent_pieces)
             : this_colour_pieces(this_colour_pieces), opponent_pieces(opponent_pieces) {};
+        Bitboard pawn_standard_starting_position() override;
         Bitboard pawn_push_targets(Bitboard sources) override;
         Bitboard pawn_push_sources(Bitboard targets) override;
         Bitboard pawn_east_attack_targets(Bitboard sources) override;
@@ -75,6 +78,7 @@ class White : public Colour {
 class Piece {
     public:
         virtual ~Piece() = default;
+        virtual Bitboard current_position() = 0;
         virtual void make_move(Square source, Square target) = 0;
         virtual void make_capture(Square target) = 0;
         virtual bool has_piece_on_square(Square square_index) = 0;
@@ -85,6 +89,7 @@ class NullPiece : public Piece {
     public:
         NullPiece() = default;
         ~NullPiece() = default;
+        Bitboard current_position() override { return Bitboard(0); };
         void make_move(Square source, Square target) override {};
         void make_capture(Square target) override {};
         bool has_piece_on_square(Square square_index) override { return 0; };
@@ -94,15 +99,17 @@ class NullPiece : public Piece {
 class Pawns : public Piece {
 
     private:
-        std::shared_ptr<Bitboard> board;
+        Bitboard board;
         std::shared_ptr<Bitboard> empty_squares;
         std::shared_ptr<Colour> colour;
         Bitboard single_push();
         Bitboard double_push();
         Bitboard all_attack();
     public:
-        Pawns(std::shared_ptr<Bitboard> board,
-              std::shared_ptr<Bitboard> empty_squares,
+        Pawns(std::shared_ptr<Bitboard> empty_squares,
+              std::shared_ptr<Colour> colour) 
+              : board(Bitboard(0)), empty_squares(empty_squares) , colour(colour) {};
+        Pawns(Bitboard board, std::shared_ptr<Bitboard> empty_squares,
               std::shared_ptr<Colour> colour) 
               : board(board), empty_squares(empty_squares) , colour(colour) {};
         ~Pawns() = default;
@@ -110,6 +117,8 @@ class Pawns : public Piece {
         PawnTargets double_pushes();
         PawnTargets west_captures();
         PawnTargets east_captures();
+        void standard_starting_position();
+        Bitboard current_position() override;
         void make_move(Square source, Square target) override;
         void make_capture(Square target) override;
         bool has_piece_on_square(Square square_index) override;

--- a/test/movegen_test.cpp
+++ b/test/movegen_test.cpp
@@ -16,8 +16,10 @@ TEST(MoveGenTest, CanCreateObject) {
     auto white_pieces = std::make_shared<pieces::White>(white_piece_bitboard, black_piece_bitboard);
     auto black_pieces = std::make_shared<pieces::Black>(black_piece_bitboard, white_piece_bitboard);
 
-    auto white_pawns = std::make_shared<pieces::Pawns>(white_pawns_bitboard, empty_squares_ptr, white_pieces);
-    auto black_pawns = std::make_shared<pieces::Pawns>(black_pawns_bitboard, empty_squares_ptr, white_pieces);
+    auto white_pawns = std::make_shared<pieces::Pawns>(empty_squares_ptr, white_pieces);
+    auto black_pawns = std::make_shared<pieces::Pawns>(empty_squares_ptr, white_pieces);
+    white_pawns->standard_starting_position();
+    black_pawns->standard_starting_position();
 
     pieces::ChessMen white_side = pieces::ChessMen(white_pawns);
     pieces::ChessMen black_side = pieces::ChessMen(black_pawns);
@@ -32,20 +34,33 @@ TEST(MoveGenTest, CanCreateObject) {
 }
 
 TEST(MoveGenTest, DetectsLegalCaptures) {
+    
+    //   Test Board       W Pawn Targets           Targets
+    // . . . . . . . .    . . . . . . . .    . . . . . . . . 
+    // . . . . . . . .    . . . . . . . .    . . . . . . . . 
+    // . . . . . . . .    . . . . . . . .    1 1 . 1 1 1 1 1 
+    // . . . . . . . .    . . . . . . . .    . . . . . . . . 
+    // . . . . . . . .    . 1 . . . . . .    . . . . . . . . 
+    // . . p . . . . .    . 1 1 . . . . .    . . . . . . . . 
+    // . P . . . . . .    . . . . . . . .    . . . . . . . . 
+    // . . . . . . . .    . . . . . . . .    . . . . . . . . 
+
+
     // Assemble
-    auto white_pawns_bitboard = std::make_shared<Bitboard>(bitboard::RANK_2);
-    auto extra_black_pawn = bitboard::RANK_3 & bitboard::FILE_C;
-    auto black_pawns_bitboard = std::make_shared<Bitboard>(bitboard::RANK_7 ^ extra_black_pawn);
-    auto occupied = *white_pawns_bitboard ^ *black_pawns_bitboard;
+    auto white_pawns_bitboard = bitboard::RANK_2 & bitboard::FILE_B;
+    auto black_pawns_bitboard = bitboard::RANK_3 & bitboard::FILE_C;
+
+    auto occupied = white_pawns_bitboard ^ black_pawns_bitboard;
     auto empty_squares_ptr = std::make_shared<Bitboard>(~occupied);
-    auto black_piece_bitboard = std::make_shared<Bitboard> (*black_pawns_bitboard);
-    auto white_piece_bitboard = std::make_shared<Bitboard> (*white_pawns_bitboard);
+    auto black_piece_bitboard = std::make_shared<Bitboard> (black_pawns_bitboard);
+    auto white_piece_bitboard = std::make_shared<Bitboard> (white_pawns_bitboard);
 
     auto white_pieces = std::make_shared<pieces::White>(white_piece_bitboard, black_piece_bitboard);
     auto black_pieces = std::make_shared<pieces::Black>(black_piece_bitboard, white_piece_bitboard);
 
     auto white_pawns = std::make_shared<pieces::Pawns>(white_pawns_bitboard, empty_squares_ptr, white_pieces);
     auto black_pawns = std::make_shared<pieces::Pawns>(black_pawns_bitboard, empty_squares_ptr, black_pieces);
+
 
     pieces::ChessMen white_side = pieces::ChessMen(white_pawns);
     pieces::ChessMen black_side = pieces::ChessMen(black_pawns);
@@ -56,21 +71,14 @@ TEST(MoveGenTest, DetectsLegalCaptures) {
     auto move_stack = move_generator.generate_pseudo_legal_moves();
 
     // Assert
-    auto expected_white_pawn_positions = bitboard::RANK_2 & bitboard::NOT_FILE_B;
-    expected_white_pawn_positions ^= extra_black_pawn;
-    occupied = expected_white_pawn_positions ^ bitboard::RANK_7;
-    EXPECT_EQ(move_stack.size(), 16);
+    EXPECT_EQ(move_stack.size(), 3);
     move_stack.top()->execute();
-    EXPECT_EQ(*black_pawns_bitboard, bitboard::RANK_7);
-    EXPECT_EQ(*black_piece_bitboard, bitboard::RANK_7);
-    EXPECT_EQ(*white_pawns_bitboard, expected_white_pawn_positions);
-    EXPECT_EQ(*white_piece_bitboard, expected_white_pawn_positions);
-    EXPECT_EQ(*empty_squares_ptr, ~occupied);
+    EXPECT_EQ(black_pawns->current_position(), 0);
+    EXPECT_EQ(white_pawns->current_position(), black_pawns_bitboard);
+    EXPECT_EQ(*empty_squares_ptr, ~black_pawns_bitboard);
     move_stack.top()->undo();
-    EXPECT_EQ(*black_pawns_bitboard, bitboard::RANK_7 ^ extra_black_pawn);
-    EXPECT_EQ(*black_piece_bitboard, bitboard::RANK_7 ^ extra_black_pawn);
-    EXPECT_EQ(*white_pawns_bitboard, bitboard::RANK_2);
-    EXPECT_EQ(*white_piece_bitboard, bitboard::RANK_2);
-    occupied = *white_pawns_bitboard ^ *black_pawns_bitboard;
+    EXPECT_EQ(black_pawns->current_position(), black_pawns_bitboard);
+    EXPECT_EQ(white_pawns->current_position(), white_pawns_bitboard);
+    occupied = white_pawns_bitboard ^ black_pawns_bitboard;
     EXPECT_EQ(*empty_squares_ptr, ~occupied);
 }

--- a/test/pieces_test.cpp
+++ b/test/pieces_test.cpp
@@ -8,14 +8,15 @@
 
 TEST(WhitePawnsTest, CanGenerateSinglePushesFromUnobstructedStartingPosition) {
     // Assemble
-    auto pawns_bitboard = std::make_shared<Bitboard>(bitboard::RANK_2);
-    auto empty_squares_ptr = std::make_shared<Bitboard>(~*pawns_bitboard);
+    auto pawns_bitboard = bitboard::RANK_2;
+    auto empty_squares_ptr = std::make_shared<Bitboard>(~pawns_bitboard);
     auto black_pieces = std::make_shared<Bitboard> (0);
-    auto white_pieces = std::make_shared<Bitboard> (*pawns_bitboard);
+    auto white_pieces = std::make_shared<Bitboard> (pawns_bitboard);
 
     auto WhitePieces = std::make_shared<pieces::White>(white_pieces, black_pieces);
-    auto pawns = pieces::Pawns(pawns_bitboard, empty_squares_ptr, WhitePieces);
-    
+    auto pawns = pieces::Pawns(empty_squares_ptr, WhitePieces);
+    pawns.standard_starting_position();
+
     // Act
     auto single_push_moves = pawns.single_pushes();
 
@@ -26,46 +27,46 @@ TEST(WhitePawnsTest, CanGenerateSinglePushesFromUnobstructedStartingPosition) {
 
 TEST(WhitePawnsTest, DoublePushOnlyAllowedFromRank2) {
     // Assemble
-    auto pawns_bitboard = std::make_shared<Bitboard>(bitboard::RANK_2);
-    auto empty_squares_ptr = std::make_shared<Bitboard>(~*pawns_bitboard);
+    auto pawns_bitboard = bitboard::RANK_2;
+    auto empty_squares_ptr = std::make_shared<Bitboard>(~pawns_bitboard);
     auto black_pieces = std::make_shared<Bitboard> (0);
-    auto white_pieces = std::make_shared<Bitboard> (*pawns_bitboard);
+    auto white_pieces = std::make_shared<Bitboard> (pawns_bitboard);
 
     auto WhitePieces = std::make_shared<pieces::White>(white_pieces, black_pieces);
-    auto pawns = pieces::Pawns(pawns_bitboard, empty_squares_ptr, WhitePieces);
+    auto pawns = pieces::Pawns(empty_squares_ptr, WhitePieces);
+    pawns.standard_starting_position();
 
     std::vector<pieces::PawnTargets> moves;
 
     // Act
     for (int i = 2; i <= 8; i++) {
         moves.push_back(pawns.double_pushes());
-        *pawns_bitboard = bitboard::north_one(*pawns_bitboard);
-        *empty_squares_ptr = ~*pawns_bitboard;
+        pawns_bitboard = bitboard::north_one(pawns_bitboard);
     }
 
     // Assert
     EXPECT_EQ(moves[0].get_source(), bitboard::RANK_2);
-    EXPECT_EQ(moves[1].get_source(), 0);
-    EXPECT_EQ(moves[2].get_source(), 0);
-    EXPECT_EQ(moves[3].get_source(), 0);
-    EXPECT_EQ(moves[4].get_source(), 0);
-    EXPECT_EQ(moves[5].get_source(), 0);
-    EXPECT_EQ(moves[6].get_source(), 0); 
+    EXPECT_EQ(moves[1].get_source(), bitboard::RANK_2);
+    EXPECT_EQ(moves[2].get_source(), bitboard::RANK_2);
+    EXPECT_EQ(moves[3].get_source(), bitboard::RANK_2);
+    EXPECT_EQ(moves[4].get_source(), bitboard::RANK_2);
+    EXPECT_EQ(moves[5].get_source(), bitboard::RANK_2);
+    EXPECT_EQ(moves[6].get_source(), bitboard::RANK_2); 
 }
 
 TEST(WhitePawnsTest, OpponentPieceBlocksPawnPushes) {
     // Tests if an opponent piece can block pawn pushes
 
     // Assemble
-    auto pawns_bitboard = std::make_shared<Bitboard>(bitboard::RANK_2);
+    auto pawns_bitboard = bitboard::RANK_2;
     auto black_pieces = std::make_shared<Bitboard> (bitboard::RANK_3 & bitboard::FILE_C);
-    auto white_pieces = std::make_shared<Bitboard> (*pawns_bitboard);
+    auto white_pieces = std::make_shared<Bitboard> (pawns_bitboard);
     auto occupied_squares = *black_pieces ^ *white_pieces;
     auto empty_squares_ptr = std::make_shared<Bitboard>(~occupied_squares);
 
     auto WhitePieces = std::make_shared<pieces::White>(white_pieces, black_pieces);
-    auto pawns = pieces::Pawns(pawns_bitboard, empty_squares_ptr, WhitePieces);
-
+    auto pawns = pieces::Pawns(empty_squares_ptr, WhitePieces);
+    pawns.standard_starting_position();
     // Act
     auto moves = pawns.single_pushes();
 
@@ -87,15 +88,16 @@ TEST(WhitePawnsTest, FriendlyPieceBlocksPawnPushes) {
     // . . . . . . . .
 
     // Assemble
-    auto pawns_bitboard = std::make_shared<Bitboard>(bitboard::RANK_2);
+    auto pawns_bitboard = bitboard::RANK_2;
     auto black_pieces = std::make_shared<Bitboard>(0);
     auto extra_white_piece = bitboard::RANK_3 & bitboard::FILE_C;
-    auto white_pieces = std::make_shared<Bitboard> (*pawns_bitboard ^ extra_white_piece);
+    auto white_pieces = std::make_shared<Bitboard> (pawns_bitboard ^ extra_white_piece);
     auto occupied_squares = *black_pieces ^ *white_pieces;
     auto empty_squares_ptr = std::make_shared<Bitboard>(~occupied_squares);
 
     auto WhitePieces = std::make_shared<pieces::White>(white_pieces, black_pieces);
-    auto pawns = pieces::Pawns(pawns_bitboard, empty_squares_ptr, WhitePieces);
+    auto pawns = pieces::Pawns(empty_squares_ptr, WhitePieces);
+    pawns.standard_starting_position();
 
     // Act
     auto moves = pawns.single_pushes();
@@ -119,14 +121,15 @@ TEST(WhitePawnsTest, OpponentPieceCanBeCaptured) {
     // . . . . . . . .
 
     // Assemble
-    auto pawn_bitboard = std::make_shared<Bitboard>(bitboard::RANK_2);
+    auto pawn_bitboard = bitboard::RANK_2;
     auto black_pieces = std::make_shared<Bitboard> (bitboard::RANK_3 & bitboard::FILE_C);
-    auto white_pieces = std::make_shared<Bitboard> (*pawn_bitboard);
+    auto white_pieces = std::make_shared<Bitboard> (pawn_bitboard);
     auto occupied_squares = *black_pieces ^ *white_pieces;
     auto empty_squares_ptr = std::make_shared<Bitboard>(~occupied_squares);
 
     auto WhitePieces = std::make_shared<pieces::White>(white_pieces, black_pieces);
-    auto pawns = pieces::Pawns(pawn_bitboard, empty_squares_ptr, WhitePieces);
+    auto pawns = pieces::Pawns(empty_squares_ptr, WhitePieces);
+    pawns.standard_starting_position();
 
     // Act
     auto west_moves = pawns.west_captures();
@@ -147,8 +150,9 @@ TEST(BlackPawnsTest, CanGenerateSinglePushesFromUnobstructedStartingPosition) {
     auto white_pieces = std::make_shared<Bitboard> (*pawn_bitboard);
 
     auto BlackPieces = std::make_shared<pieces::Black>(black_pieces, white_pieces);
-    auto pawns = pieces::Pawns(pawn_bitboard, empty_squares_ptr, BlackPieces);
-    
+    auto pawns = pieces::Pawns(empty_squares_ptr, BlackPieces);
+    pawns.standard_starting_position();
+
     // Act
     auto single_push_moves = pawns.single_pushes();
 
@@ -166,25 +170,24 @@ TEST(BlackPawnsTest, DoublePushOnlyAllowedFromRank7) {
     auto white_pieces = std::make_shared<Bitboard>(*pawn_bitboard);
 
     auto BlackPieces = std::make_shared<pieces::Black>(black_pieces, white_pieces);
-    auto pawns = pieces::Pawns(pawn_bitboard, empty_squares_ptr, BlackPieces);
+    auto pawns = pieces::Pawns(empty_squares_ptr, BlackPieces);
+    pawns.standard_starting_position();
 
     std::vector<pieces::PawnTargets> moves;
 
     // Act
     for (int i = 2; i <= 8; i++) {
         moves.push_back(pawns.double_pushes());
-        *pawn_bitboard = bitboard::south_one(*pawn_bitboard);
-        *empty_squares_ptr = ~*pawn_bitboard;
     }
 
     // Assert
     EXPECT_EQ(moves[0].get_source(), bitboard::RANK_7);
-    EXPECT_EQ(moves[1].get_source(), 0);
-    EXPECT_EQ(moves[2].get_source(), 0);
-    EXPECT_EQ(moves[3].get_source(), 0);
-    EXPECT_EQ(moves[4].get_source(), 0);
-    EXPECT_EQ(moves[5].get_source(), 0);
-    EXPECT_EQ(moves[6].get_source(), 0);
+    EXPECT_EQ(moves[1].get_source(), bitboard::RANK_7);
+    EXPECT_EQ(moves[2].get_source(), bitboard::RANK_7);
+    EXPECT_EQ(moves[3].get_source(), bitboard::RANK_7);
+    EXPECT_EQ(moves[4].get_source(), bitboard::RANK_7);
+    EXPECT_EQ(moves[5].get_source(), bitboard::RANK_7);
+    EXPECT_EQ(moves[6].get_source(), bitboard::RANK_7);
 }
 
 TEST(BlackPawnsTest, OpponentPieceBlocksPawnPushes) {
@@ -208,7 +211,8 @@ TEST(BlackPawnsTest, OpponentPieceBlocksPawnPushes) {
     auto empty_squares_ptr = std::make_shared<Bitboard>(~occupied_squares);
 
     auto BlackPieces = std::make_shared<pieces::Black>(black_pieces, white_pieces);
-    auto pawns = pieces::Pawns(pawn_bitboard, empty_squares_ptr, BlackPieces);
+    auto pawns = pieces::Pawns(empty_squares_ptr, BlackPieces);
+    pawns.standard_starting_position();
 
     // Act
     auto moves = pawns.single_pushes();
@@ -240,8 +244,8 @@ TEST(BlackPawnsTest, FriendlyPieceBlocksPawnPushes) {
     auto empty_squares_ptr = std::make_shared<Bitboard>(~occupied_squares);
 
     auto BlackPieces = std::make_shared<pieces::Black>(black_pieces, white_pieces);
-    auto pawns = pieces::Pawns(pawn_bitboard, empty_squares_ptr, BlackPieces);
-
+    auto pawns = pieces::Pawns(empty_squares_ptr, BlackPieces);
+    pawns.standard_starting_position();
     // Act
     auto moves = pawns.single_pushes();
 
@@ -272,7 +276,8 @@ TEST(BlackPawnsTest, OpponentPieceCanBeCaptured) {
     auto empty_squares_ptr = std::make_shared<Bitboard>(~occupied_squares);
 
     auto BlackPieces = std::make_shared<pieces::Black>(black_pieces, white_pieces);
-    auto pawns = pieces::Pawns(pawn_bitboard, empty_squares_ptr, BlackPieces);
+    auto pawns = pieces::Pawns(empty_squares_ptr, BlackPieces);
+    pawns.standard_starting_position();
 
     // Act
     auto west_moves = pawns.west_captures();


### PR DESCRIPTION
The bitboard used by the Pawns class needed to be created outside the
class (as a std::shared_ptr<Bitboard> and given to it through the
constuctor. This meant there there was potential for this pointer to
remain owned by a user outside the Pawns class, and potential for its
state to be changed by that user without access to the Pawns object at
all.

The constructor Pawns class has been modified and a second constuctor
added. The original constructor no longer takes the board by reference
but by value, while the new constructor allows for the Pawns object to
be created without providing a bitboard at all. In the new constructor,
if the object is created with out specifing a bitboard of piece
positions then the board is initialised as empty (Bitboard(0)).

Two methods have been added to the class, one that returns the current
state of the bitboard (this is a method that was added to Pawns base
class Piece, and is overridden by Pawns). The second added method allows
for bitboard to be set to the standard starting position of the Pawns
(either rank 2 for white pawns, or rank 4 for black pawns). Due to the
different starting positions of white and black pieces this is
implemented by adding methods to the classes derived from the Colour
class.

Tests have been updated to reflect the changes to the interface of the
Pawns class.